### PR TITLE
Correctly setting 'methods' and 'suppressQuery'

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -31,8 +31,8 @@ var ProxyServer = exports.ProxyServer = function(options) {
     port: options.port || 80,
     path: options.path || '',
     headers: options.headers || {},
-    methods: 'GET',
-    supressQuery: false
+    methods: options.methods || 'GET',
+    supressQuery: options.supressQuery || false
   };
 
   this.host = options.host;


### PR DESCRIPTION
'methods' and 'suppressQuery' were hard coded and didn't respect actual parameters passed from instantiation
