### PR TITLE
Added removeHandlers to ProxyServer

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -230,6 +230,10 @@ ProxyServer.prototype.removeHandler = function() {
   return this;
 };
 
+ProxyServer.prototype.removeHandlers = function() {
+  this.handlers = [];
+};
+
 
 exports.createServer = function (options) {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intercept-proxy",
   "description": "A light weight proxy for exposing a remote site through localhost and replace select resources with local versions for testing and development purposes.",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "authors": [
     "Johan Öbrink <johan.obrink@gmail.com> (https://github.com/johanobrink)"
   ],

--- a/tests/registerHandler-test.js
+++ b/tests/registerHandler-test.js
@@ -86,6 +86,21 @@ describe('handlers', function() {
       expect(server.handlers['/foo']['PUT']).to.equal(handler);
     });
 
+    it('should remove all handlers', function() {
+      var handler = function(req, res) {};
+
+      server.addHandler('/foo', 'GET', handler);
+      server.addHandler('/foo2', 'GET', handler);
+
+      expect(server.handlers['/foo']['GET']).to.equal(handler);
+      expect(server.handlers['/foo2']['GET']).to.equal(handler);
+
+      server.removeHandlers();
+
+      expect(server.handlers['/foo']).to.be.undefined;
+      expect(server.handlers['/foo2']).to.be.undefined;
+    });
+
     describe('calls to handlers', function() {
       it('should call a handler for matching path', function(done) {
 


### PR DESCRIPTION
Having a method to remove all the handlers would be helpful. In my app, for example, the user is given the option to change his proxy configuration even after the original handlers were set.

This PR includes the `ProxyServer.prototype.addHandlers`, the unit test, and a minor package bump.
